### PR TITLE
Fix redeemToken URL

### DIFF
--- a/js/token.js
+++ b/js/token.js
@@ -7,7 +7,7 @@ export const TokenAPI = superclass =>
         }
 
         async redeemToken(token) {
-            const url = this.baseUrl + "accounts/redeem";
+            const url = this.baseUrl + "tokens/redeem";
             const contents = await this.post(url, {
                 params: {
                     token: token


### PR DESCRIPTION
Changed the redeemToken function URL from `accounts/redeem` to `tokens/redeem`.