### PR TITLE
fix: don't use auth in recover account function

### DIFF
--- a/js/account.js
+++ b/js/account.js
@@ -59,7 +59,11 @@ export const AccountAPI = superclass =>
 
         async recoverAccount(username) {
             const url = this.baseUrl + `accounts/${username}/recover`;
-            const contents = await this.post(url);
+            const contents = await this.post(url, {
+                kwargs: {
+                    auth: false
+                }
+            });
             return contents;
         }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Not using auth in recover password request. |
| Animated GIF | -- |